### PR TITLE
ipq60xx:Fix device tree missing nodes

### DIFF
--- a/target/linux/ipq60xx/files-4.4/arch/arm64/boot/dts/qcom/qcom-ipq6018-redmi-ax5-jdcloud.dts
+++ b/target/linux/ipq60xx/files-4.4/arch/arm64/boot/dts/qcom/qcom-ipq6018-redmi-ax5-jdcloud.dts
@@ -4,8 +4,8 @@
 
 /dts-v1/;
 
-#include "ipq6018.dtsi"
-#include "ipq6018-cpr-regulator.dtsi"
+#include "qcom-ipq6018.dtsi"
+#include "qcom-ipq6018-cpr-regulator.dtsi"
 #include <dt-bindings/input/input.h>
 
 / {

--- a/target/linux/ipq60xx/files-4.4/arch/arm64/boot/dts/qcom/qcom-ipq6018-redmi-ax5-jdcloud.dts
+++ b/target/linux/ipq60xx/files-4.4/arch/arm64/boot/dts/qcom/qcom-ipq6018-redmi-ax5-jdcloud.dts
@@ -6,6 +6,8 @@
 
 #include "qcom-ipq6018.dtsi"
 #include "qcom-ipq6018-cpr-regulator.dtsi"
+#include "qcom-ipq6018-rpm-regulator.dtsi"
+#include "qcom-ipq6018-cp-cpu.dtsi"
 #include <dt-bindings/input/input.h>
 
 / {
@@ -181,6 +183,15 @@
 };
 
 &tlmm {
+	serial_3_pins: serial3-pinmux {
+		mux {
+			pins = "gpio44", "gpio45";
+			function = "blsp2_uart";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
 	button_pins: button_pins {
 		reset_button {
 			pins = "gpio19";
@@ -224,7 +235,7 @@
 &blsp1_uart3 {
 	pinctrl-0 = <&serial_3_pins>;
 	pinctrl-names = "default";
-	status = "ok";
+	status = "okay";
 };
 
 &nss_crypto {


### PR DESCRIPTION
编译前，修复这两个缺少和名称改正
```
  CC      drivers/block/loop.o
  DTC     arch/arm64/boot/dts/qcom/ipq6018-redmi-ax5-jdcloud.dtb
  CC      lib/halfmd4.o
  CC      crypto/chainiv.o
arch/arm64/boot/dts/qcom/ipq6018-redmi-ax5-jdcloud.dts:7:10: fatal error: ipq6018.dtsi: No such file or directory
 #include "ipq6018.dtsi"
          ^~~~~~~~~~~~~~
compilation terminated.
make[7]: *** [scripts/Makefile.lib:322: arch/arm64/boot/dts/qcom/ipq6018-redmi-ax5-jdcloud.dtb] Error 1
make[6]: *** [scripts/Makefile.build:573: arch/arm64/boot/dts/qcom] Error 2
make[5]: *** [arch/arm64/Makefile:101: dtbs] Error 2
make[5]: *** Waiting for unfinished jobs....
```

```
ERROR (phandle_references): Reference to non-existent node or label "serial_3_pins"
  CC      crypto/crypto_null.o

ERROR (phandle_references): Reference to non-existent node or label "ipq6018_s2_corner"

ERROR: Input tree has errors, aborting (use -f to force output)
make[7]: *** [scripts/Makefile.lib:322: arch/arm64/boot/dts/qcom/qcom-ipq6018-redmi-ax5-jdcloud.dtb] Error 2
make[7]: *** Waiting for unfinished jobs....
```
